### PR TITLE
Close customizer menu with button in PTS

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -249,10 +249,10 @@ void DisplayApp::Refresh() {
         }
       } break;
       case Messages::ButtonPushed:
-        if (currentApp == Apps::Clock) {
-          PushMessageToSystemTask(System::Messages::GoToSleep);
-        } else {
-          if (!currentScreen->OnButtonPushed()) {
+        if (!currentScreen->OnButtonPushed()) {
+          if (currentApp == Apps::Clock) {
+            PushMessageToSystemTask(System::Messages::GoToSleep);
+          } else {
             LoadApp(returnToApp, returnDirection);
             brightnessController.Set(settingsController.GetBrightness());
             brightnessController.Backup();

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -54,6 +54,10 @@ bool Clock::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
   return screen->OnTouchEvent(event);
 }
 
+bool Clock::OnButtonPushed() {
+  return screen->OnButtonPushed();
+}
+
 std::unique_ptr<Screen> Clock::WatchFaceDigitalScreen() {
   return std::make_unique<Screens::WatchFaceDigital>(app,
                                                      dateTimeController,

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -32,6 +32,7 @@ namespace Pinetime {
         ~Clock() override;
 
         bool OnTouchEvent(TouchEvents event) override;
+        bool OnButtonPushed() override;
 
       private:
         Controllers::DateTime& dateTimeController;

--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -316,6 +316,27 @@ bool PineTimeStyle::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
   return false;
 }
 
+void PineTimeStyle::CloseMenu() {
+  settingsController.SaveSettings();
+  lv_obj_set_hidden(btnNextTime, true);
+  lv_obj_set_hidden(btnPrevTime, true);
+  lv_obj_set_hidden(btnNextBar, true);
+  lv_obj_set_hidden(btnPrevBar, true);
+  lv_obj_set_hidden(btnNextBG, true);
+  lv_obj_set_hidden(btnPrevBG, true);
+  lv_obj_set_hidden(btnReset, true);
+  lv_obj_set_hidden(btnRandom, true);
+  lv_obj_set_hidden(btnClose, true);
+}
+
+bool PineTimeStyle::OnButtonPushed() {
+  if (!lv_obj_get_hidden(btnClose)) {
+    CloseMenu();
+    return true;
+  }
+  return false;
+}
+
 void PineTimeStyle::SetBatteryIcon() {
   auto batteryPercent = batteryPercentRemaining.Get();
   lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
@@ -532,16 +553,7 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
       lv_obj_set_style_local_bg_color(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT,  Convert(valueBG));
     }
     if (object == btnClose) {
-      settingsController.SaveSettings();
-      lv_obj_set_hidden(btnNextTime, true);
-      lv_obj_set_hidden(btnPrevTime, true);
-      lv_obj_set_hidden(btnNextBar, true);
-      lv_obj_set_hidden(btnPrevBar, true);
-      lv_obj_set_hidden(btnNextBG, true);
-      lv_obj_set_hidden(btnPrevBG, true);
-      lv_obj_set_hidden(btnReset, true);
-      lv_obj_set_hidden(btnRandom, true);
-      lv_obj_set_hidden(btnClose, true);
+      CloseMenu();
     }
     if (object == btnSet) {
       lv_obj_set_hidden(btnSet, true);

--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -38,8 +38,8 @@
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  static void event_handler(lv_obj_t* obj, lv_event_t event) {
-    PineTimeStyle* screen = static_cast<PineTimeStyle*>(obj->user_data);
+  void event_handler(lv_obj_t* obj, lv_event_t event) {
+    auto* screen = static_cast<PineTimeStyle*>(obj->user_data);
     screen->UpdateSelected(obj, event);
   }
 }
@@ -169,8 +169,8 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
 
   // Step count gauge
   if (settingsController.GetPTSColorBar() == Pinetime::Controllers::Settings::Colors::White) {
-    needle_colors[0] = LV_COLOR_BLACK; 
-    } else {
+    needle_colors[0] = LV_COLOR_BLACK;
+  } else {
     needle_colors[0] = LV_COLOR_WHITE;
   }
   stepGauge = lv_gauge_create(lv_scr_act(), nullptr);
@@ -305,7 +305,7 @@ PineTimeStyle::~PineTimeStyle() {
 }
 
 bool PineTimeStyle::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  if ((event == Pinetime::Applications::TouchEvents::LongTap) && (lv_obj_get_hidden(btnRandom) == true)) {
+  if ((event == Pinetime::Applications::TouchEvents::LongTap) && lv_obj_get_hidden(btnRandom)) {
     lv_obj_set_hidden(btnSet, false);
     savedTick = lv_tick_get();
     return true;
@@ -392,7 +392,7 @@ void PineTimeStyle::Refresh() {
     char hoursChar[3];
     char ampmChar[5];
     if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-        sprintf(hoursChar, "%02d", hour);
+      sprintf(hoursChar, "%02d", hour);
     } else {
       if (hour == 0 && hour != 12) {
         hour = 12;
@@ -447,7 +447,7 @@ void PineTimeStyle::Refresh() {
       lv_obj_set_style_local_scale_grad_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
     }
   }
-  if (lv_obj_get_hidden(btnSet) == false) {
+  if (!lv_obj_get_hidden(btnSet)) {
     if ((savedTick > 0) && (lv_tick_get() - savedTick > 3000)) {
       lv_obj_set_hidden(btnSet, true);
       savedTick = 0;
@@ -463,8 +463,9 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   if (event == LV_EVENT_CLICKED) {
     if (object == btnNextTime) {
       valueTime = GetNext(valueTime);
-      if(valueTime == valueBG)
+      if (valueTime == valueBG) {
         valueTime = GetNext(valueTime);
+      }
       settingsController.SetPTSColorTime(valueTime);
       lv_obj_set_style_local_text_color(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
       lv_obj_set_style_local_text_color(timeDD2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
@@ -472,8 +473,9 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
     }
     if (object == btnPrevTime) {
       valueTime = GetPrevious(valueTime);
-      if(valueTime == valueBG)
+      if (valueTime == valueBG) {
         valueTime = GetPrevious(valueTime);
+      }
       settingsController.SetPTSColorTime(valueTime);
       lv_obj_set_style_local_text_color(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
       lv_obj_set_style_local_text_color(timeDD2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
@@ -481,11 +483,12 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
     }
     if (object == btnNextBar) {
       valueBar = GetNext(valueBar);
-      if(valueBar == Controllers::Settings::Colors::Black)
+      if (valueBar == Controllers::Settings::Colors::Black) {
         valueBar = GetNext(valueBar);
-      if(valueBar == Controllers::Settings::Colors::White) {
-        needle_colors[0] = LV_COLOR_BLACK; 
-        } else {
+      }
+      if (valueBar == Controllers::Settings::Colors::White) {
+        needle_colors[0] = LV_COLOR_BLACK;
+      } else {
         needle_colors[0] = LV_COLOR_WHITE;
       }
       settingsController.SetPTSColorBar(valueBar);
@@ -493,11 +496,12 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
     }
     if (object == btnPrevBar) {
       valueBar = GetPrevious(valueBar);
-      if(valueBar == Controllers::Settings::Colors::Black)
+      if (valueBar == Controllers::Settings::Colors::Black) {
         valueBar = GetPrevious(valueBar);
-      if(valueBar == Controllers::Settings::Colors::White) {
-        needle_colors[0] = LV_COLOR_BLACK; 
-        } else {
+      }
+      if (valueBar == Controllers::Settings::Colors::White) {
+        needle_colors[0] = LV_COLOR_BLACK;
+      } else {
         needle_colors[0] = LV_COLOR_WHITE;
       }
       settingsController.SetPTSColorBar(valueBar);
@@ -505,15 +509,17 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
     }
     if (object == btnNextBG) {
       valueBG = GetNext(valueBG);
-      if(valueBG == valueTime)
+      if (valueBG == valueTime) {
         valueBG = GetNext(valueBG);
+      }
       settingsController.SetPTSColorBG(valueBG);
       lv_obj_set_style_local_bg_color(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueBG));
     }
     if (object == btnPrevBG) {
       valueBG = GetPrevious(valueBG);
-      if(valueBG == valueTime)
+      if (valueBG == valueTime) {
         valueBG = GetPrevious(valueBG);
+      }
       settingsController.SetPTSColorBG(valueBG);
       lv_obj_set_style_local_bg_color(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueBG));
     }
@@ -545,12 +551,12 @@ void PineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) {
       }
       settingsController.SetPTSColorTime(static_cast<Controllers::Settings::Colors>(valueTime));
       lv_obj_set_style_local_text_color(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
-      lv_obj_set_style_local_text_color(timeDD2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT,  Convert(valueTime));
-      lv_obj_set_style_local_text_color(timeAMPM, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT,  Convert(valueTime));
+      lv_obj_set_style_local_text_color(timeDD2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
+      lv_obj_set_style_local_text_color(timeAMPM, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTime));
       settingsController.SetPTSColorBar(static_cast<Controllers::Settings::Colors>(valueBar));
-      lv_obj_set_style_local_bg_color(sidebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT,  Convert(valueBar));
+      lv_obj_set_style_local_bg_color(sidebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueBar));
       settingsController.SetPTSColorBG(static_cast<Controllers::Settings::Colors>(valueBG));
-      lv_obj_set_style_local_bg_color(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT,  Convert(valueBG));
+      lv_obj_set_style_local_bg_color(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueBG));
     }
     if (object == btnClose) {
       CloseMenu();

--- a/src/displayapp/screens/PineTimeStyle.h
+++ b/src/displayapp/screens/PineTimeStyle.h
@@ -54,8 +54,8 @@ namespace Pinetime {
         DirtyValue<uint32_t> stepCount {};
         DirtyValue<bool> notificationState {};
 
-        Pinetime::Controllers::Settings::Colors GetNext(Controllers::Settings::Colors color);
-        Pinetime::Controllers::Settings::Colors GetPrevious(Controllers::Settings::Colors color);
+        static Pinetime::Controllers::Settings::Colors GetNext(Controllers::Settings::Colors color);
+        static Pinetime::Controllers::Settings::Colors GetPrevious(Controllers::Settings::Colors color);
 
         lv_obj_t* btnNextTime;
         lv_obj_t* btnPrevTime;

--- a/src/displayapp/screens/PineTimeStyle.h
+++ b/src/displayapp/screens/PineTimeStyle.h
@@ -31,6 +31,7 @@ namespace Pinetime {
         ~PineTimeStyle() override;
 
         bool OnTouchEvent(TouchEvents event) override;
+        bool OnButtonPushed() override;
 
         void Refresh() override;
 
@@ -96,6 +97,7 @@ namespace Pinetime {
         Controllers::MotionController& motionController;
 
         void SetBatteryIcon();
+        void CloseMenu();
 
         lv_task_t* taskRefresh;
       };


### PR DESCRIPTION
Currently displayapp doesn't run `currentScreen->OnButtonPushed()` if the screen is the clock, so that had to be changed. Then Clock.cpp had to be updated to "forward" the event to the actual watchface.

I also clang-format and clang-tidied the files for you.